### PR TITLE
Add variant target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install all dependencies and start it by running:
 ```bash
 $ npm install && npm start
 ```
-You should be able to see if its running by opening http://localhost:8001.
+You should be able to see if it's running by opening http://localhost:8001.
 
 #### RHMAP
 Create a node _Cloud App_ inside your project and push this code to its git repository (git link in _Details_ section), then simply deploy the app (In _Deploy_ section). Remember to select a node version greater than or equal to 4.4.
@@ -27,3 +27,4 @@ The format is like this:
     }
 }
 ```
+Note: this is only necessary when using the push/ups routes.

--- a/app-auth.json
+++ b/app-auth.json
@@ -1,6 +1,10 @@
 {
     "l2k3v4iyu3jlcy7hquocuvo7": {
-        "pushApplicationID": "249bf721-d6a6-480d-9c1f-1a0c60ba2198",
+        "pushApplicationID": "19a76440-d257-4370-b57a-1d7c3c1bb76f",
         "masterSecret": "44a5b6b5-bedc-4ebb-b597-49ce836b9c07"
+    },
+    "l2k3v4msg44oddq7wnsczsih": {
+        "pushApplicationID": "01c63659-79c0-4add-98e0-dbc906b3c251",
+        "masterSecret": "39855ee1-a781-43f3-b5a8-429273fe1b73"
     }
 }

--- a/app-auth.json
+++ b/app-auth.json
@@ -1,6 +1,6 @@
 {
-    "kf6ractk5zo4zeurbve45s63": {
-        "pushApplicationID": "89c757e7-110e-4abd-a9e5-f047253caeae",
-        "masterSecret": "97f06583-b188-4478-bc99-f36510db7a63"
+    "l2k3v4iyu3jlcy7hquocuvo7": {
+        "pushApplicationID": "249bf721-d6a6-480d-9c1f-1a0c60ba2198",
+        "masterSecret": "44a5b6b5-bedc-4ebb-b597-49ce836b9c07"
     }
 }

--- a/app-auth.json
+++ b/app-auth.json
@@ -1,6 +1,6 @@
 {
-    "myAppId": {
-        "pushApplicationID": "app1234567",
-        "masterSecret": "supersecret!"
+    "kf6ractk5zo4zeurbve45s63": {
+        "pushApplicationID": "89c757e7-110e-4abd-a9e5-f047253caeae",
+        "masterSecret": "97f06583-b188-4478-bc99-f36510db7a63"
     }
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "body-parser": "~1.0.2",
     "cors": "~2.2.0",
     "express": "~4.0.0",
-    "fh-mbaas-api": "6.1.4",
+    "fh-mbaas-api": "7.0.11",
     "request": "2.79.0",
     "winston": "^2.3.1"
   },

--- a/public/index.html
+++ b/public/index.html
@@ -79,7 +79,7 @@
 </body>
 
 <script language="javascript">
-    document.getElementById("version").innerText = "0.1.0";
+    document.getElementById("version").innerText = "0.1.8";
 
 </script>
 

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,10 @@
     <meta http-equiv="content-type" content="text/html; charset=UTF-8">
     <meta name="robots" content="noindex, nofollow">
     <meta name="googlebot" content="noindex, nofollow">
-    <script type="text/javascript" src="/js/lib/dummy.js"></script>
+
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha256-k2WSCIexGzOj3Euiig+TlR8gA0EmPjuc79OEeY5L45g="
+        crossorigin="anonymous"></script>
+
     <link rel="stylesheet" type="text/css" href="/css/result-light.css">
 
     <style type="text/css">
@@ -14,13 +17,42 @@
             position: absolute;
             bottom: 0px;
         }
-        
+
         .image {
             display: inline-block;
             position: absolute;
             bottom: 0;
         }
-        
+
+        .bubble_container {
+            position: absolute;
+            left: 55%;
+            top: 22%;
+
+            animation: fadein 1s;
+            -webkit-animation: fadein 1s;
+        }
+
+        @keyframes fadein {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        @-o-keyframes fadein {
+            from { opacity: 0; }
+            to { opacity: 1; }
+        }
+
+        .bubble {
+            width: 160px;
+        }
+
+        #version {
+            position: absolute;
+            top: 19%;
+            left: 32%;
+        }
+
         body {
             overflow: hidden;
         }
@@ -31,6 +63,13 @@
 
 <body>
     <div class="image_container">
+        <div class="bubble_container">
+            <div class="bubble_inner_container">
+                <img src="https://img.clipartfest.com/e1a66d12c2a7cce3882669887c2fca61_-cartoon-bubble-images-comic-bubble-clip-art_1512-1355.png"
+                    alt="bubble" class="bubble">
+                <h1 id="version"></h1>
+            </div>
+        </div>
         <img data-original-width="500" data-original-height="364" data-padding-top="59" data-id="bcKmIWkUMCjVm" data-image_url="https://media.giphy.com/media/bcKmIWkUMCjVm/giphy.gif"
             data-bitly_gif_url="http://gph.is/18hMuOc" data-mp4_url="https://media.giphy.com/media/bcKmIWkUMCjVm/giphy.mp4" data-still="https://media.giphy.com/media/bcKmIWkUMCjVm/giphy_s.gif"
             data-preview-image-url="https://media.giphy.com/media/bcKmIWkUMCjVm/100.gif" data-tumblr_share_url="https://media.giphy.com/media/bcKmIWkUMCjVm/giphy-downsized.gif"
@@ -38,5 +77,10 @@
             id="gif" class="a-gif" src="https://media.giphy.com/media/bcKmIWkUMCjVm/giphy.gif" alt="animated cartoons &amp; comics hello hey welcome">
     </div>
 </body>
+
+<script language="javascript">
+    document.getElementById("version").innerText = "0.1.0";
+
+</script>
 
 </html>

--- a/spec/service/ups-api.spec.js
+++ b/spec/service/ups-api.spec.js
@@ -7,18 +7,13 @@ const Criteria = require("../../src/model/criteria");
 describe("UPSAPI", () => {
 
     let api;
-
-    beforeAll(() => {
-        spyOn(UPSAPI.prototype, "getCredentials").and.returnValue(
-            {
-                pushApplicationID: "id",
-                masterSecret: "secret"
-            }
-        );
-    });
+    const credentials = {
+        pushApplicationID: "id",
+        masterSecret: "secret"
+    };
 
     beforeEach(() => {
-        api = new UPSAPI();
+        api = new UPSAPI(credentials);
     });
 
     describe(".sendNotificationToAlias", () => {
@@ -57,6 +52,24 @@ describe("UPSAPI", () => {
             api.sendNotificationsToAliasesInBatch(aliases);
 
             expect(api.post.calls.mostRecent().args[2]).toEqual(notifications);
+        });
+
+    });
+
+    describe(".sendNotificationToVariant", () => {
+
+        it("should send {message, criteria} in the body", () => {
+            spyOn(api, "post");
+
+            const variant = "alias";
+
+            const message = new Message(`Hello ${variant} from rhmap-push-cloud-app!`);
+            const criteria = new Criteria();
+            criteria.alias = [variant];
+
+            api.sendNotificationToAlias(variant);
+
+            expect(api.post.calls.mostRecent().args[2]).toEqual({ message, criteria });
         });
 
     });

--- a/src/model/criteria.js
+++ b/src/model/criteria.js
@@ -5,7 +5,7 @@ class Criteria {
         this.alias = [];
         this.deviceType;
         this.categories;
-        this.variants;
+        this.variants = [];
     }
 }
 

--- a/src/model/options.js
+++ b/src/model/options.js
@@ -25,6 +25,10 @@ class Options {
     set appId(appId) {
         this.apps[0] = appId;
     }
+
+    set variant(variant) {
+        this.criteria.variants[0] = variant;
+    }
 }
 
 module.exports = Options;

--- a/src/model/options.js
+++ b/src/model/options.js
@@ -3,13 +3,14 @@
 const Criteria = require("./criteria");
 const Config = require("./config");
 
-const DEFAULT_OPTIONS_BROADCAST = false;
+// TODO why is broadcast required? Broadcast is to send it to every device, right? https://github.com/fheng/millicore/blob/master/src/main/java/com/feedhenry/controller/UnifiedPushController.java#L71
+const DEFAULT_OPTIONS_BROADCAST = true;
 
 class Options {
     constructor() {
         this.config = new Config();
         this.criteria = new Criteria();
-        this.apps = [];
+        this.apps;
         this.broadcast = DEFAULT_OPTIONS_BROADCAST;
         this.appId;
     }

--- a/src/model/options.js
+++ b/src/model/options.js
@@ -29,6 +29,10 @@ class Options {
     set variant(variant) {
         this.criteria.variants[0] = variant;
     }
+
+    set variants(variants) {
+        this.criteria.variants = variants;
+    }
 }
 
 module.exports = Options;

--- a/src/route/push-fh.js
+++ b/src/route/push-fh.js
@@ -18,7 +18,7 @@ pushFH.use(bodyParser());
  * @param appId ID of the mobile app that will be target of the notification.
  * @param alias Alias that will be target of the notification.
  */
-pushFH.get("/:appId/:alias", (request, response) => {
+pushFH.get("/:appId/alias/:alias", (request, response) => {
     const appId = request.params.appId;
     const alias = request.params.alias;
 
@@ -32,7 +32,7 @@ pushFH.get("/:appId/:alias", (request, response) => {
  * The list of aliases must be provided in the request's body in form of array.
  * @param appId ID of the mobile app that has the devices.
  */
-pushFH.post("/:appId", (request, response) => {
+pushFH.post("/:appId/alias", (request, response) => {
     const appId = request.params.appId;
     const aliases = request.body;
 
@@ -51,7 +51,7 @@ pushFH.post("/:appId", (request, response) => {
  * A list of aliases must be provided in the request's body in form of array.
  * @param appId ID of the mobile app that will be target of the notification.
  */
-pushFH.post("/:appId/batch", (request, response) => {
+pushFH.post("/:appId/alias/batch", (request, response) => {
     const appId = request.params.appId;
     const aliases = request.body;
 
@@ -72,6 +72,20 @@ pushFH.get("/:appId/variants/:variantId", (request, response) => {
     Logger.log(`[${appId}] Sending push to variant: ${variantId} using fh.push().`);
 
     FHAPI.sendNotificationToVariant(variantId, CallbackFactory.getCallback(response, variantId));
+});
+
+/**
+ * Send a push notification to a multiple variant using $fh.push.
+ * App's ID and masterSecret must be provided via basic auth.
+ * A list of variant IDs must be provided in the request's body in form of array.
+ * @param appId ID of the mobile app that has the devices.
+ */
+pushFH.post("/:appId/variants", (request, response) => {
+    const variants = request.body;
+
+    Logger.log(`[${variants.length} variants] Sending push using $fh.push.`);
+
+    FHAPI.sendNotificationToVariants(variants, CallbackFactory.getCallback(response, `${variants.length} variants`));
 });
 
 module.exports = pushFH;

--- a/src/route/push-fh.js
+++ b/src/route/push-fh.js
@@ -24,13 +24,13 @@ pushFH.get("/:appId/:alias", (request, response) => {
 
     Logger.log(`[${appId}] Sending push to ${alias} using fh.push().`);
 
-    FHAPI.sendNotificationToAlias(alias, CallbackFactory.getCallback(response, appId, alias));
+    FHAPI.sendNotificationToAlias(alias, CallbackFactory.getCallback(response, alias));
 });
 
 /**
- * Send a push notification to a list of aliases using $fh.push in an async.each() loop. That is, all notifications will be sent simoultaniously but in different requests.
+ * Send a push notification to a list of aliases using $fh.push in an async.each() loop. That is, all notifications will be sent simultaneously but in different requests.
  * The list of aliases must be provided in the request's body in form of array.
- * @param appId pushApplicationID of the mobile app that has the devices.
+ * @param appId ID of the mobile app that has the devices.
  */
 pushFH.post("/:appId", (request, response) => {
     const appId = request.params.appId;
@@ -39,7 +39,7 @@ pushFH.post("/:appId", (request, response) => {
     Logger.log(`[${appId}] Sending push to ${aliases.length} devices asynchronously using fh.push().`);
 
     async.each(aliases,
-        alias => FHAPI.sendNotificationToAlias(alias, CallbackFactory.getCallback(response, appId, alias)),
+        alias => FHAPI.sendNotificationToAlias(alias, CallbackFactory.getCallback(response, alias)),
         err => Logger.error(`[${appId}] Async Error: ${err}.`)
     );
 
@@ -58,6 +58,20 @@ pushFH.post("/:appId/batch", (request, response) => {
     Logger.log(`[${appId}] Sending push to ${aliases.length} devices in a batch using fh.push().`);
 
     FHAPI.sendNotificationToAliasesInBatch(aliases, CallbackFactory.getCallback(response, appId));
+});
+
+/**
+ * Send a push notification to a single variant using $fh.push.
+ * @param appId ID of the mobile app that has the devices.
+ * @param variantId ID of variant that will be receiving the notification.
+ */
+pushFH.get("/:appId/variants/:variantId", (request, response) => {
+    const appId = request.params.appId;
+    const variantId = request.params.variantId;
+
+    Logger.log(`[${appId}] Sending push to variant: ${variantId} using fh.push().`);
+
+    FHAPI.sendNotificationToVariant(variantId, CallbackFactory.getCallback(response, variantId));
 });
 
 module.exports = pushFH;

--- a/src/route/push-ups.js
+++ b/src/route/push-ups.js
@@ -7,15 +7,18 @@ const async = require("async");
 const Logger = require("../util/logger");
 const UPSAPI = require("../service/ups-api");
 const CallbackFactory = require("../service/api-callback-factory");
+const AuthChecker = require("../util/auth-checker");
 
 const pushUPS = new express.Router();
 
 pushUPS.use(cors());
 pushUPS.use(bodyParser());
 
+const authChecker = new AuthChecker();
+
 /**
  * Send a notification to a single alias.
- * App's pushApplicationID and masterSecret must be provided via basic auth.
+ * App's ID and masterSecret must be provided via basic auth.
  *
  * @param appId ID of the mobile app that will be target of the notification.
  * @param alias Alias that will be target of the notification.
@@ -26,15 +29,20 @@ pushUPS.get("/:appId/:alias", (request, response) => {
 
     Logger.log(`[${appId}] Sending push to ${alias} using UPS RestAPI.`);
 
-    new UPSAPI(appId)
-        .sendNotificationToAlias(alias, CallbackFactory.getCallback(response, appId, alias));
+    const credentials = authChecker.getCredentialsForAppId(appId);
+    if (credentials) {
+        new UPSAPI(credentials)
+            .sendNotificationToAlias(alias, CallbackFactory.getCallback(response, alias));
+    } else {
+        response.status(404).send(`AppId not found: ${appId}`);
+    }
 });
 
 /**
  * Send a push notification to a list of aliases using UPS RestAPI in an async.each() loop. That is, all notifications will be sent simoultaniously but in different requests.
- * App's pushApplicationID and masterSecret must be provided via basic auth.
+ * App's ID and masterSecret must be provided via basic auth.
  * The list of aliases must be provided in the request's body in form of array.
- * @param appId pushApplicationID of the mobile app that has the devices.
+ * @param appId ID of the mobile app that has the devices.
  */
 pushUPS.post("/:appId", (request, response) => {
     const appId = request.params.appId;
@@ -42,18 +50,23 @@ pushUPS.post("/:appId", (request, response) => {
 
     Logger.log(`[${appId}] Sending push to ${aliases.length} devices asynchronously using UPS RestAPI.`);
 
-    const api = new UPSAPI(appId);
-    async.each(aliases,
-        alias => api.sendNotificationToAlias(alias, CallbackFactory.getCallback(response, appId, alias)),
-        err => Logger.error(`[${appId}] Async Error: ${err}.`)
-    );
+    const credentials = authChecker.getCredentialsForAppId(appId);
+    if (credentials) {
+        const api = new UPSAPI(credentials);
+        async.each(aliases,
+            alias => api.sendNotificationToAlias(alias, CallbackFactory.getCallback(response, alias)),
+            err => Logger.error(`[${appId}] Async Error: ${err}.`)
+        );
 
-    response.send(`Sending push to ${aliases.length} devices asynchronously. Check the Cloud App logs for results.`);
+        response.send(`Sending push to ${aliases.length} devices asynchronously. Check the Cloud App logs for results.`);
+    } else {
+        response.status(404).send(`AppId not found: ${appId}`);
+    }
 });
 
 /**
  * Send a batch of notifications to different aliases using UPS RestAPI in a single request.
- * App's pushApplicationID and masterSecret must be provided via basic auth.
+ * App's ID and masterSecret must be provided via basic auth.
  * A list of aliases must be provided in the request's body in form of array.
  * @param appId ID of the mobile app that will be target of the notification.
  */
@@ -63,8 +76,55 @@ pushUPS.post("/:appId/batch", (request, response) => {
 
     Logger.log(`[${appId}] Sending push to ${aliases.length} devices in a batch using UPS RestAPI.`);
 
-    new UPSAPI(appId)
-        .sendNotificationsToAliasesInBatch(aliases, CallbackFactory.getCallback(response, appId));
+    const credentials = authChecker.getCredentialsForAppId(appId);
+    if (credentials) {
+        new UPSAPI(credentials)
+            .sendNotificationsToAliasesInBatch(aliases, CallbackFactory.getCallback(response, appId));
+    } else {
+        response.status(404).send(`AppId not found: ${appId}`);
+    }
+});
+
+/**
+ * Send a push notification to a single variant using UPS RestAPI.
+ * App's ID and masterSecret must be provided via basic auth.
+ * @param appId ID of the mobile app that has the devices.
+ * @param variantId Id of the variant that will be receiving the notification.
+ */
+pushUPS.get("/:appId/variants/:variantId", (request, response) => {
+    const appId = request.params.appId;
+    const variantId = request.params.variantId;
+
+    Logger.log(`[${appId}] Sending push to variant: ${variantId} using UPS RestAPI.`);
+
+    const credentials = authChecker.getCredentialsForAppId(appId);
+    if (credentials) {
+        new UPSAPI(credentials)
+            .sendNotificationToVariant(variantId, CallbackFactory.getCallback(response, variantId));
+    } else {
+        response.status(404).send(`AppId not found: ${appId}`);
+    }
+});
+
+/**
+ * Send a push notification to a multiple variant using UPS RestAPI.
+ * App's ID and masterSecret must be provided via basic auth.
+ * A list of variant IDs must be provided in the request's body in form of array.
+ * @param appId ID of the mobile app that has the devices.
+ */
+pushUPS.post("/:appId/variants", (request, response) => {
+    const appId = request.params.appId;
+    const variants = request.body;
+
+    Logger.log(`[${variants.length} variants] Sending push using UPS RestAPI.`);
+
+    const credentials = authChecker.getCredentialsForAppId(appId);
+    if (credentials) {
+        new UPSAPI(credentials)
+            .sendNotificationToVariants(variants, CallbackFactory.getCallback(response, `${variants.length} variants`));
+    } else {
+        response.status(404).send(`AppId not found: ${appId}`);
+    }
 });
 
 module.exports = pushUPS;

--- a/src/route/push-ups.js
+++ b/src/route/push-ups.js
@@ -23,7 +23,7 @@ const authChecker = new AuthChecker();
  * @param appId ID of the mobile app that will be target of the notification.
  * @param alias Alias that will be target of the notification.
  */
-pushUPS.get("/:appId/:alias", (request, response) => {
+pushUPS.get("/:appId/alias/:alias", (request, response) => {
     const appId = request.params.appId;
     const alias = request.params.alias;
 
@@ -44,7 +44,7 @@ pushUPS.get("/:appId/:alias", (request, response) => {
  * The list of aliases must be provided in the request's body in form of array.
  * @param appId ID of the mobile app that has the devices.
  */
-pushUPS.post("/:appId", (request, response) => {
+pushUPS.post("/:appId/alias", (request, response) => {
     const appId = request.params.appId;
     const aliases = request.body;
 
@@ -70,7 +70,7 @@ pushUPS.post("/:appId", (request, response) => {
  * A list of aliases must be provided in the request's body in form of array.
  * @param appId ID of the mobile app that will be target of the notification.
  */
-pushUPS.post("/:appId/batch", (request, response) => {
+pushUPS.post("/:appId/alias/batch", (request, response) => {
     const appId = request.params.appId;
     const aliases = request.body;
 

--- a/src/service/api-callback-factory.js
+++ b/src/service/api-callback-factory.js
@@ -12,7 +12,8 @@ class APICallbackFactory {
 
             } else if (res) {
                 Logger.log(`[${receiver}] Response (${res.statusCode}): ${res.body}`);
-                response.status(res.statusCode).send(res.body);
+                // response.status(res.statusCode).send(res.body || undefined);
+                response.status(200).send(res);
 
             } else {
                 Logger.log(`[${receiver}] No error or response.`);

--- a/src/service/api-callback-factory.js
+++ b/src/service/api-callback-factory.js
@@ -4,18 +4,18 @@ const Logger = require("../util/logger");
 
 class APICallbackFactory {
 
-    static getCallback(response, appId, alias) {
+    static getCallback(response, receiver) {
         return (err, res) => {
             if (err) {
-                Logger.log(`[${alias || appId}] CloudApp error: ${err}`);
+                Logger.log(`[${receiver}] CloudApp error: ${err}`);
                 response.status(500).send(err);
 
             } else if (res) {
-                Logger.log(`[${alias || appId}] Response (${res.statusCode}): ${res.body}`);
+                Logger.log(`[${receiver}] Response (${res.statusCode}): ${res.body}`);
                 response.status(res.statusCode).send(res.body);
 
             } else {
-                Logger.log(`[${alias || appId}] No error or response.`);
+                Logger.log(`[${receiver}] No error or response.`);
                 response.send("No response");
             }
         };

--- a/src/service/fh-api.js
+++ b/src/service/fh-api.js
@@ -34,6 +34,16 @@ class FHAPI {
         callback(undefined, { statusCode: 404, body: "Not yet implemented" });
     }
 
+    static sendNotificationToVariant(variant, callback) {
+        Logger.log(`[${variant}] Sending push using fh.push().`);
+
+        const message = new Message(`Hello ${variant} from rhmap-push-cloud-app!`);
+        const options = new Options();
+        options.variant = variant;
+
+        $fh.push(message, options, callback);
+    }
+
 }
 
 module.exports = FHAPI;

--- a/src/service/fh-api.js
+++ b/src/service/fh-api.js
@@ -47,7 +47,7 @@ class FHAPI {
     static sendNotificationToVariants(variants, callback) {
         Logger.log(`[${variants.length} variants] Sending push using fh.push().`);
 
-        const message = new Message(`Hello ${variants.toString()} from rhmap-push-cloud-app!`);
+        const message = new Message(`Hello ${variants.length} variants from rhmap-push-cloud-app!`);
         const options = new Options();
         options.variants = variants;
 

--- a/src/service/fh-api.js
+++ b/src/service/fh-api.js
@@ -44,6 +44,15 @@ class FHAPI {
         $fh.push(message, options, callback);
     }
 
+    static sendNotificationToVariants(variants, callback) {
+        Logger.log(`[${variants.length} variants] Sending push using fh.push().`);
+
+        const message = new Message(`Hello ${variants.toString()} from rhmap-push-cloud-app!`);
+        const options = new Options();
+        options.variants = variants;
+
+        $fh.push(message, options, callback);
+    }
 }
 
 module.exports = FHAPI;

--- a/src/service/fh-api.js
+++ b/src/service/fh-api.js
@@ -47,7 +47,7 @@ class FHAPI {
     static sendNotificationToVariants(variants, callback) {
         Logger.log(`[${variants.length} variants] Sending push using fh.push().`);
 
-        const message = new Message(`Hello ${variants.length} variants from rhmap-push-cloud-app!`);
+        const message = new Message(`Hello ${variants.toString()} from rhmap-push-cloud-app!`);
         const options = new Options();
         options.variants = variants;
 

--- a/src/service/ups-api.js
+++ b/src/service/ups-api.js
@@ -53,7 +53,7 @@ class UPSAPI {
     }
 
     sendNotificationToVariants(variants, callback) {
-        const message = new Message(`Hello ${variants.length} variants from rhmap-push-cloud-app!`);
+        const message = new Message(`Hello ${variants.toString()} from rhmap-push-cloud-app!`);
         const criteria = new Criteria();
         criteria.variants = variants;
 

--- a/src/service/ups-api.js
+++ b/src/service/ups-api.js
@@ -17,6 +17,7 @@ class UPSAPI {
         this.pushApplicationID = credentials.pushApplicationID;
         this.masterSecret = credentials.masterSecret;
     }
+
     sendNotificationToAlias(alias, callback) {
         Logger.log(`[${alias}] Sending push using fh.push().`);
 

--- a/src/service/ups-api.js
+++ b/src/service/ups-api.js
@@ -4,9 +4,8 @@ const request = require("request");
 const Message = require("../model/message");
 const Criteria = require("../model/criteria");
 const Logger = require("../util/logger");
-const AuthChecker = require("../util/auth-checker");
 
-const PUSH_URL = "http://testing.eteam.skunkhenry.com/api/v2/ag-push/rest/sender";
+const PUSH_URL = "https://testing.zeta.feedhenry.com/api/v2/ag-push/rest/sender";
 const PUSH_BATCH_URL = `${PUSH_URL}/batch`;
 
 /**
@@ -14,16 +13,10 @@ const PUSH_BATCH_URL = `${PUSH_URL}/batch`;
  */
 class UPSAPI {
 
-    constructor(appId) {
-        const credentials = this.getCredentials(appId);
+    constructor(credentials) {
         this.pushApplicationID = credentials.pushApplicationID;
         this.masterSecret = credentials.masterSecret;
     }
-
-    getCredentials(appId) {
-        return new AuthChecker().getCredentialsForAppId(appId);
-    }
-
     sendNotificationToAlias(alias, callback) {
         Logger.log(`[${alias}] Sending push using fh.push().`);
 
@@ -33,7 +26,7 @@ class UPSAPI {
 
         const body = { message, criteria };
 
-        this.post(PUSH_BATCH_URL, callback, body);
+        this.post(PUSH_URL, callback, body);
     }
 
     sendNotificationsToAliasesInBatch(aliases, callback) {
@@ -46,6 +39,26 @@ class UPSAPI {
         });
 
         this.post(PUSH_BATCH_URL, callback, notifications);
+    }
+
+    sendNotificationToVariant(variant, callback) {
+        const message = new Message(`Hello ${variant} from rhmap-push-cloud-app!`);
+        const criteria = new Criteria();
+        criteria.variants = [variant];
+
+        const body = { message, criteria };
+
+        this.post(PUSH_URL, callback, body);
+    }
+
+    sendNotificationToVariants(variants, callback) {
+        const message = new Message(`Hello ${variants.toString()} from rhmap-push-cloud-app!`);
+        const criteria = new Criteria();
+        criteria.variants = variants;
+
+        const body = { message, criteria };
+
+        this.post(PUSH_URL, callback, body);
     }
 
     post(url, callback, body) {

--- a/src/service/ups-api.js
+++ b/src/service/ups-api.js
@@ -53,7 +53,7 @@ class UPSAPI {
     }
 
     sendNotificationToVariants(variants, callback) {
-        const message = new Message(`Hello ${variants.toString()} from rhmap-push-cloud-app!`);
+        const message = new Message(`Hello ${variants.length} variants from rhmap-push-cloud-app!`);
         const criteria = new Criteria();
         criteria.variants = variants;
 

--- a/src/util/auth-checker.js
+++ b/src/util/auth-checker.js
@@ -25,6 +25,7 @@ class AuthChecker {
     }
 
     readDataFromJSON() {
+        // TODO: check that the file exists
         const data = fs.readFileSync(this.path, "utf8");
 
         return JSON.parse(data);


### PR DESCRIPTION
Added a new route /variants that allows sending notifications to a list of variants. In order to maintain consistency, the original functionality has been moved to the route /alias.

### Previous routes
```
GET    /appId/aliasId
POST   /appId
```
### New routes
```
GET    /appId/alias/aliasId
POST   /appId/alias
GET    /appId/variants/variantId
POST   /appId/variants
```